### PR TITLE
Enable computation of reverse ipv6 from ipv6

### DIFF
--- a/dns/util/default.nix
+++ b/dns/util/default.nix
@@ -23,6 +23,30 @@ let
     then ''"${s}"''
     else concatMapStringsSep " " (x: ''"${x}"'') (splitInGroupsOf 255 s);
 
+  # : str -> str, with length 4 (zeros are padded to the left)
+  align4Bytes = lib.fixedWidthString 4 "0";
+
+  # : int -> str -> str
+  # Expands "" to 4n zeros and aligns the rest on 4 bytes
+  align4BytesOrExpand = n: v:
+    if v == ""
+    then (lib.fixedWidthString (4*n) "0" "")
+    else align4Bytes v;
+
+  # : str -> [ str ]
+  # Returns the record of the ipv6 as a list
+  mkRecordAux = v6:
+    let
+      splitted = lib.splitString ":" v6;
+      n = 8 - builtins.length (lib.filter (x: x != "") splitted);
+    in
+      lib.stringToCharacters (lib.concatMapStrings (align4BytesOrExpand n) splitted);
+
+  # : str -> str
+  # Returns the reversed record of the ipv6
+  mkReverseRecord = v6:
+    lib.concatStringsSep "." (lib.reverseList (mkRecordAux v6)) + ".ip6.arpa";
+
 in {
-  inherit writeCharacterString;
+  inherit writeCharacterString mkReverseRecord;
 }


### PR DESCRIPTION
Hi,

Here is a PR that enables the computation of reverse ipv6 from ipv6.

Example on: `2001:db8:1:42::54`

We first expand each nibble by adding zeros: `2001:0db8:0001:0042::0054`,
then we add the zeros to deal with `::` (if needed): `2001:0db8:0001:0042:0000:0000:0000:0054`,
we finally reverse the result and format it: `4.5.0.0.0.0.0.0.0.0.0.0.0.0.0.0.2.4.0.0.1.0.0.0.8.b.d.0.1.0.0.2`.

I wrote a function (`mkReverseRecord`) to make this computation simpler.