### PR TITLE
 Add DANE and DANE-Related RRs

### DIFF
--- a/dns/types/records/HTTPS.nix
+++ b/dns/types/records/HTTPS.nix
@@ -1,0 +1,3 @@
+args: import ./SVCB.nix args // {
+  rtype = "HTTPS";
+}

--- a/dns/types/records/OPENPGPKEY.nix
+++ b/dns/types/records/OPENPGPKEY.nix
@@ -1,0 +1,20 @@
+# RFC7929
+
+{ lib }:
+
+let
+  inherit (lib) dns mkOption types;
+
+in
+
+{
+  rtype = "OPENPGPKEY";
+  options = {
+    data = mkOption {
+      type = types.str;
+    };
+  };
+
+  dataToString = { data, ... }: dns.util.writeCharacterString data;
+  fromString = data: { inherit data; };
+}

--- a/dns/types/records/SSHFP.nix
+++ b/dns/types/records/SSHFP.nix
@@ -1,0 +1,40 @@
+# RFC 4255
+
+{ lib }:
+
+let
+  inherit (lib) dns mkOption types;
+  inherit (builtins) attrNames;
+  algorithm = {
+    "rsa" = 1;
+    "dsa" = 2;
+    "ecdsa" = 3; # RFC 6594
+    "ed25519" = 4; # RFC 7479 / RFC 8709
+    "ed448" = 6; # RFC 8709
+  };
+  mode = {
+    "sha1" = 1;
+    "sha256" = 2; # RFC 6594
+  };
+in
+
+{
+  rtype = "SSHFP";
+  options = {
+    algorithm = mkOption {
+      example = "ed25519";
+      type = types.enum (attrNames algorithm);
+      apply = value: algorithm.${value};
+    };
+    mode = mkOption {
+      example = "sha256";
+      type = types.enum (attrNames mode);
+      apply = value: mode.${value};
+    };
+    fingerprint = mkOption {
+      type = types.str;
+    };
+  };
+  dataToString = { algorithm, mode, fingerprint, ... }:
+    "${toString algorithm} ${toString mode} ${fingerprint}";
+}

--- a/dns/types/records/SSHFP.nix
+++ b/dns/types/records/SSHFP.nix
@@ -35,6 +35,6 @@ in
       type = types.str;
     };
   };
-  dataToString = { algorithm, mode, fingerprint, ... }:
-    "${toString algorithm} ${toString mode} ${fingerprint}";
+  dataToString = { algorithm, fingerprintType, fingerprint, ... }:
+    "${toString algorithm} ${toString fingerprintType} ${fingerprint}";
 }

--- a/dns/types/records/SSHFP.nix
+++ b/dns/types/records/SSHFP.nix
@@ -26,7 +26,7 @@ in
       type = types.enum (attrNames algorithm);
       apply = value: algorithm.${value};
     };
-    mode = mkOption {
+    fingerprintType = mkOption {
       example = "sha256";
       type = types.enum (attrNames mode);
       apply = value: mode.${value};

--- a/dns/types/records/SVCB.nix
+++ b/dns/types/records/SVCB.nix
@@ -1,0 +1,63 @@
+# draft-ietf-dnsop-svcb-https-08
+
+{ lib }:
+
+let
+  inherit (lib) dns mkOption types;
+  inherit (builtins) attrNames;
+  listToStringComma = lib.concatStringsSep ",";
+  optionalListToStringComma = v: if v == null then null else listToStringComma v;
+  optionalOption = name: value: if value == null then "" else "${name}=${value}";
+  optionalBool = name: value: if value then "${name}" else "";
+  optionalInt = name: value: toString (optionalOption name value);
+  optionalList = name: value: optionalOption name (optionalListToStringComma value);
+in
+rec {
+  rtype = "SVCB";
+  options = {
+    svcPriority = mkOption {
+      example = 1;
+      type = types.int;
+    };
+    targetName = mkOption {
+      example = ".";
+      type = types.str;
+    };
+    mandatory = mkOption {
+      example = [ "ipv4hint" ];
+      default = null;
+      type = types.nullOr (types.listOf types.str);
+    };
+    alpn = mkOption {
+      example = [ "h2" ];
+      default = null;
+      type = types.nullOr (types.listOf types.str);
+    };
+    no-default-alpn = mkOption {
+      example = true;
+      default = false;
+      type = types.bool;
+    };
+    port = mkOption {
+      example = 443;
+      default = null;
+      type = types.nullOr types.int;
+    };
+    ipv4hint = mkOption {
+      example = [ "127.0.0.1" ];
+      default = null;
+      type = types.nullOr (types.listOf types.str);
+    };
+    ipv6hint = mkOption {
+      example = [ "::1" ];
+      default = null;
+      type = types.nullOr (types.listOf types.str);
+    };
+    ech = mkOption {
+      type = types.nullOr types.str;
+      default = null;
+    };
+  };
+  dataToString = { svcPriority, targetName, mandatory ? null, alpn ? null, no-default-alpn ? null, port ? null, ipv4hint ? null, ipv6hint ? null, ech ? null, ... }:
+    "${toString svcPriority} ${targetName} ${optionalList "mandatory" mandatory} ${optionalList "alpn" alpn} ${optionalBool "no-default-alpn" no-default-alpn} ${optionalInt "port" port} ${optionalList "ipv4hint" ipv4hint} ${optionalList "ipv6hint" ipv6hint} ${optionalOption "ech" ech}";
+}

--- a/dns/types/records/SVCB.nix
+++ b/dns/types/records/SVCB.nix
@@ -14,7 +14,7 @@ let
     types
     ;
 
-  mkSvcParams = concatStringsSep " " (
+  mkSvcParams = params: concatStringsSep " " (
     filter (s: s != "") (
       mapAttrsToList (
         name: value:
@@ -26,11 +26,11 @@ let
           "${name}=${builtins.toString value}"
         else
           ""
-      ) config
+      ) params
     )
   );
 in
-rec {
+{
   rtype = "SVCB";
   options = {
     svcPriority = mkOption {
@@ -89,5 +89,5 @@ rec {
       port
       ;
   }
-}"
+}";
 }

--- a/dns/types/records/TLSA.nix
+++ b/dns/types/records/TLSA.nix
@@ -1,0 +1,49 @@
+# RFC 6698
+
+{ lib }:
+
+let
+  inherit (lib) dns mkOption types;
+  inherit (builtins) attrNames;
+
+  certUsage = {
+    "pkix-ta" = 0;
+    "pkix-ee" = 1;
+    "dane-ta" = 2;
+    "dane-ee" = 3;
+  };
+  selectors = {
+    "cert" = 0;
+    "spki" = 1;
+  };
+  match = {
+    "full" = 0;
+    "sha256" = 1;
+    "sha512" = 2;
+  };
+in
+{
+  rtype = "TLSA";
+  options = {
+    certUsage = mkOption {
+      example = "dane-ee";
+      type = types.enum (attrNames certUsage);
+      apply = value: certUsage.${value};
+    };
+    selector = mkOption {
+      example = "spki";
+      type = types.enum (attrNames selectors);
+      apply = value: selectors.${value};
+    };
+    match = mkOption {
+      example = "sha256";
+      type = types.enum (attrNames match);
+      apply = value: match.${value};
+    };
+    certificate = mkOption {
+      type = types.str;
+    };
+  };
+  dataToString = { certUsage, selector, match, certificate, ... }:
+    "${toString certUsage} ${toString selector} ${toString match} ${certificate}";
+}

--- a/dns/types/records/TLSA.nix
+++ b/dns/types/records/TLSA.nix
@@ -17,7 +17,7 @@ let
     "spki" = 1;
   };
   match = {
-    "full" = 0;
+    "exact" = 0;
     "sha256" = 1;
     "sha512" = 2;
   };
@@ -35,7 +35,7 @@ in
       type = types.enum (attrNames selectors);
       apply = value: selectors.${value};
     };
-    match = mkOption {
+    matchingType = mkOption {
       example = "sha256";
       type = types.enum (attrNames match);
       apply = value: match.${value};

--- a/dns/types/records/default.nix
+++ b/dns/types/records/default.nix
@@ -25,6 +25,13 @@ let
     "DNSKEY"
     "DS"
 
+    # DANE types
+    "SSHFP"
+    "TLSA"
+    "OPENPGPKEY"
+    "SVCB"
+    "HTTPS"
+
     # Pseudo types
     "DKIM"
     "DMARC"

--- a/example.nix
+++ b/example.nix
@@ -33,7 +33,7 @@ let
     MX = mx.google;
 
     TXT = [
-      (with spf; strict ["a:mail.example.com" google])
+      (with spf; strict [ "a:mail.example.com" google ])
     ];
 
     DMARC = [ (dmarc.postmarkapp "mailto:re+abcdefghijk@dmarc.postmarkapp.com") ];
@@ -41,10 +41,39 @@ let
     CAA = letsEncrypt "admin@example.com";
 
     SRV = [
-      { service = "sip";
+      {
+        service = "sip";
         proto = "tcp";
         port = 5060;
         target = "sip.example.com";
+      }
+    ];
+
+    SSHFP = [
+      {
+        algorithm = "ed25519";
+        mode = "sha256";
+        fingerprint = "899EB4AC9285578AFDA3CCBE152EE78D8618B8F3862FEF2703E1FC7011E9B8AA";
+      }
+    ];
+    OPENPGPKEY = [
+      "very long base64 text"
+    ];
+    HTTPS = [
+      {
+        svcPriority = 1;
+        targetName = ".";
+        alpn = [ "http/1.1" "h2" "h3" ];
+        ipv4hint = [ "203.0.113.1" "203.0.113.2" "203.0.113.3" ];
+        ipv6hint = [ "4321:0:1:2:3:4:567:89ab" ];
+      }
+    ];
+    TLSA = [
+      {
+        certUsage = "dane-ee";
+        selector = "spki";
+        match = "sha256";
+        certificate = "899EB4AC9285578AFDA3CCBE152EE78D8618B8F3862FEF2703E1FC7011E9B8AA";
       }
     ];
 

--- a/example.nix
+++ b/example.nix
@@ -52,7 +52,7 @@ let
     SSHFP = [
       {
         algorithm = "ed25519";
-        mode = "sha256";
+        fingerprintType = "sha256";
         fingerprint = "899EB4AC9285578AFDA3CCBE152EE78D8618B8F3862FEF2703E1FC7011E9B8AA";
       }
     ];
@@ -72,7 +72,7 @@ let
       {
         certUsage = "dane-ee";
         selector = "spki";
-        match = "sha256";
+        matchingType = "sha256";
         certificate = "899EB4AC9285578AFDA3CCBE152EE78D8618B8F3862FEF2703E1FC7011E9B8AA";
       }
     ];


### PR DESCRIPTION
Some of the zones I manage use TLSA, OPENPGPKEY, SSHFP, and HTTPS resource records.

TLSA allows for pinning a certificate or the public key for the service it is for.
OPENPGPKEY allows looking up public keys on DNS, as opposed to a keyserver
SSHFP allows pinning the expected SSH Public Key hashes to DNS, which helps secure the TOFU model SSH has

The other two added resource records, SVCB and HTTPS, are currently in draft phase, but the latter is already implemented in Chrome and Firefox. The HTTPS record in particular is used as a DNS-based Strict Transport Security policy

The examples for TLSA and OPENPGPKEY I added are not how you are meant to deploy them. I added them to test if my code works.

(This is unchanged from the previous PR which was closed because i renamed the master branch to something more appropriate)