### PR TITLE
Unqualified domain names

### DIFF
--- a/dns/types/record.nix
+++ b/dns/types/record.nix
@@ -8,7 +8,7 @@
 { lib }:
 
 let
-  inherit (lib) isString mkOption types;
+  inherit (lib) isString mkOption types removeSuffix;
 
   recordType = rsubt:
     let
@@ -57,7 +57,7 @@ writeRecordRel = name: rsubt: data:
           # add default values for the record type
           (recordType rsubt).merge [] [ { file = ""; value = rsubt.fromString data; } ]
         else data;
-      name' = rsubt.nameFixup or (n: _: n) name data';
+      name' = removeSuffix ".@" (rsubt.nameFixup or (n: _: n) name data');
       rtype = rsubt.rtype;
     in lib.concatStringsSep " " (with data'; [
         "${name'}"

--- a/dns/types/record.nix
+++ b/dns/types/record.nix
@@ -50,9 +50,29 @@ let
         (rsubt.dataToString data')
       ]);
 
+writeRecordRel = name: rsubt: data:
+    let
+      data' =
+        if isString data && rsubt ? fromString then
+          # add default values for the record type
+          (recordType rsubt).merge [] [ { file = ""; value = rsubt.fromString data; } ]
+        else data;
+      name' = rsubt.nameFixup or (n: _: n) name data';
+      rtype = rsubt.rtype;
+    in lib.concatStringsSep " " (with data'; [
+        "${name'}"
+      ] ++ lib.optionals (ttl != null) [
+        (toString ttl)
+      ] ++ [
+        class
+        rtype
+        (rsubt.dataToString data')
+      ]);
+
 in
 
 {
   inherit recordType;
   inherit writeRecord;
+  inherit writeRecordRel;
 }

--- a/dns/types/zone.nix
+++ b/dns/types/zone.nix
@@ -102,9 +102,9 @@ let
             $ORIGIN ${name}.
             $TTL ${toString TTL}
 
-            ${writeRecordRel "@" rsubtypes.SOA SOA}
+            ${writeRecord "@" rsubtypes.SOA SOA}
 
-            ${writeSubzoneRel name zone}
+            ${writeSubzone "@" zone}
           ''
 	      else
           ''

--- a/dns/types/zone.nix
+++ b/dns/types/zone.nix
@@ -13,7 +13,7 @@ let
                      mapAttrsToList optionalString;
   inherit (lib) mkOption literalExample types;
 
-  inherit (import ./record.nix { inherit lib; }) recordType writeRecord writeRecordRel;
+  inherit (import ./record.nix { inherit lib; }) recordType writeRecord;
 
   rsubtypes = import ./records { inherit lib; };
   rsubtypes' = removeAttrs rsubtypes ["SOA"];
@@ -56,18 +56,6 @@ let
     in
       concatStringsSep "\n\n" groups'
       + optionalString (sub != "") ("\n\n" + sub);
-  writeSubzoneRel = name: zone:
-    let
-      name' = if zone ? SOA then "@" else name;
-      groupToString = pseudo: subt:
-        concatMapStringsSep "\n" (writeRecordRel name' subt) (zone."${pseudo}"); # (attrByPath [pseudo] [] zone);
-      groups = mapAttrsToList groupToString rsubtypes';
-      groups' = filter (s: s != "") groups;
-
-      writeSubzoneRel' = subname: writeSubzoneRel "${subname}";
-      sub = concatStringsSep "\n\n" (mapAttrsToList writeSubzoneRel' zone.subdomains);
-    in
-      (concatStringsSep "\n\n" groups') + optionalString (sub != "") ("\n\n" + sub);
   zone = types.submodule ({ name, ... }: {
     options = {
       useOrigin = mkOption {

--- a/dns/types/zone.nix
+++ b/dns/types/zone.nix
@@ -96,15 +96,24 @@ let
     } // subzoneOptions;
 
     config = {
-      __toString = zone@{ TTL, SOA, ... }:
-        ''
-          $TTL ${toString TTL}
-          $ORIGIN ${name}.
+      __toString = zone@{ useOrigin, TTL, SOA, ... }:
+        if useOrigin then
+          ''
+            $ORIGIN ${name}.
+            $TTL ${toString TTL}
 
-          ${writeRecordRel name rsubtypes.SOA SOA}
+            ${writeRecordRel "@" rsubtypes.SOA SOA}
 
-          ${writeSubzoneRel name zone}
-        '';
+            ${writeSubzoneRel name zone}
+          ''
+	      else
+          ''
+            $TTL ${toString TTL}
+
+            ${writeRecord name rsubtypes.SOA SOA}
+
+            ${writeSubzone name zone}
+          '';
     };
   });
 


### PR DESCRIPTION
This add a `useOrigin` option to `zone` type. It is a boolean, equals to `false` by default.
By default, it changes nothing to the actual result of `toString`.

If set to true, this change the `toString` behaviour to add `$ORIGIN` directive, and use `@` as domain name for the zone itself.
`writeRecord` has been patched accordingly if called with `@` as zone `name`.

This should address #17 

I had the need for a RPZ zone.