### PR TITLE
Pass dns as arg to zone submodules

### DIFF
--- a/dns/default.nix
+++ b/dns/default.nix
@@ -9,7 +9,7 @@
 let
   dnslib = {
     util = import ./util { inherit lib; };
-    inherit types;
+    inherit types combinators;
   };
   types = import ./types { lib = lib'; };
   lib' = lib // { dns = dnslib; };

--- a/dns/types/record.nix
+++ b/dns/types/record.nix
@@ -27,6 +27,7 @@ let
             description = "Record caching duration (in seconds)";
           };
         } // rsubt.options;
+        config._module.args = { inherit (lib) dns; };
       };
     in
       (if rsubt ? fromString then types.either types.str else lib.id) submodule;

--- a/dns/types/zone.nix
+++ b/dns/types/zone.nix
@@ -42,6 +42,7 @@ let
 
   subzone = types.submodule {
     options = subzoneOptions;
+    config._module.args = { inherit (lib) dns; };
   };
 
   writeSubzone = name: zone:
@@ -84,6 +85,7 @@ let
     } // subzoneOptions;
 
     config = {
+      _module.args = { inherit (lib) dns; };
       __toString = zone@{ useOrigin, TTL, SOA, ... }:
         if useOrigin then
           ''


### PR DESCRIPTION
allowing less verbose usage like
 `dns.lib.toString "example.com" ./example.com.nix;`
instead of
 `dns.lib.toString "example.com" (import ./example.com.nix
    { inherit dns; });`

with `example.nix` now starting with
```nix
{ dns, ... }:

with dns.combinators;

{
```