### PR TITLE
Fix example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ Then use `toString` to generate as a string.
 ``` nix
 { dns }:
 
-  zoneAsString = dns.lib.toString "example.com" (import ./example.com.nix) { inherit dns; };
+  zoneAsString = dns.lib.toString "example.com" (import ./example.com.nix { inherit dns; });
 ```
 
 


### PR DESCRIPTION
The `dns` argument should be inside the parenthesis, like is already the case for a different example in the README.