### PR TITLE
fix: perform record.fromString conversion at evaluation time

### DIFF
--- a/dns/types/record.nix
+++ b/dns/types/record.nix
@@ -29,29 +29,24 @@ let
         } // rsubt.options;
       };
     in
-      (if rsubt ? fromString then types.either types.str else lib.id) submodule;
+      (if rsubt ? fromString then types.coercedTo types.str rsubt.fromString else lib.id) submodule;
 
   # name == "@" : use unqualified domain name
   writeRecord = name: rsubt: data:
     let
-      data' =
-        if isString data && rsubt ? fromString then
-          # add default values for the record type
-          (recordType rsubt).merge [] [ { file = ""; value = rsubt.fromString data; } ]
-        else data;
-      name' = let fname = rsubt.nameFixup or (n: _: n) name data'; in
+      name' = let fname = rsubt.nameFixup or (n: _: n) name data; in
         if name == "@" then name
         else if (hasSuffix ".@" name) then removeSuffix ".@" fname
         else "${fname}.";
       rtype = rsubt.rtype;
-    in lib.concatStringsSep " " (with data'; [
+    in lib.concatStringsSep " " (with data; [
         name'
       ] ++ lib.optionals (ttl != null) [
         (toString ttl)
       ] ++ [
         class
         rtype
-        (rsubt.dataToString data')
+        (rsubt.dataToString data)
       ]);
 
 in


### PR DESCRIPTION
Instead of postponing it until serialization time. Because it's useful to have an AST that's the same regardless of any shortcuts used in a zone definition.

I.e. now these definitions will lead to the same output data structure:
```nix
NS = [ "ns1" "ns2" ];
```
And
```nix
NS = [ (ns "ns1") (ns "ns2") ];
```

Both of these still return the same zone file output as before.

I think it would be desirable to accomplish something similar with moving records that get `.nameFixup` applied into the correct spot in `.subdomains`. But I haven't yet figured out how to do so.